### PR TITLE
New mini-feature and gofmt syntax correction.

### DIFF
--- a/puppetdb.go
+++ b/puppetdb.go
@@ -201,6 +201,6 @@ func mergeParam(paramName string, paramValue string, params map[string]string) m
 func (c *Client) httpGet(endpoint string) (resp *http.Response, err error) {
 	base := strings.TrimRight(c.BaseURL, "/")
 	url := fmt.Sprintf("%s/v3/%s", base, endpoint)
-	log.Printf(url)
+	//log.Printf(url)
 	return c.httpClient.Get(url)
 }

--- a/puppetdb.go
+++ b/puppetdb.go
@@ -59,6 +59,10 @@ type NodeJson struct {
 	ReportTimestamp  string `json:"report_timestamp"`
 }
 
+type PuppetdbVersion struct {
+	Version string `json:"version"`
+}
+
 type ReportJson struct {
 	CertName             string `json:"certname"`
 	PuppetVersion        string `json:"puppet-version"`
@@ -114,9 +118,9 @@ func (c *Client) Nodes() ([]NodeJson, error) {
 }
 
 func (c *Client) FactNames() ([]string, error) {
-    ret := []string{}
-    err := c.Get(&ret, "fact-names", nil)
-    return ret, err
+	ret := []string{}
+	err := c.Get(&ret, "fact-names", nil)
+	return ret, err
 }
 
 func (c *Client) NodeFacts(node string) ([]FactJson, error) {
@@ -179,6 +183,13 @@ func (c *Client) Reports(query string, extraParams map[string]string) ([]ReportJ
 	return ret, err
 }
 
+func (c *Client) PuppetdbVersion() (PuppetdbVersion, error) {
+	path := "version"
+	ret := PuppetdbVersion{}
+	err := c.Get(&ret, path, nil)
+	return ret, err
+}
+
 func QueryToJson(query interface{}) (result string, err error) {
 	resultBytes, err := json.Marshal(query)
 	jsonQuery := string(resultBytes[:])
@@ -201,6 +212,5 @@ func mergeParam(paramName string, paramValue string, params map[string]string) m
 func (c *Client) httpGet(endpoint string) (resp *http.Response, err error) {
 	base := strings.TrimRight(c.BaseURL, "/")
 	url := fmt.Sprintf("%s/v3/%s", base, endpoint)
-	//log.Printf(url)
 	return c.httpClient.Get(url)
 }

--- a/puppetdb_test.go
+++ b/puppetdb_test.go
@@ -75,7 +75,7 @@ func TestFactNames(t *testing.T) {
 	if err != nil {
 		t.Errorf("FactNames() returned error: %v", err)
 	}
-    want := []string{"fact1", "fact2", "fact3"}
+	want := []string{"fact1", "fact2", "fact3"}
 	if !reflect.DeepEqual(facts, want) {
 		t.Errorf("FactNames() returned %+v, want %+v",
 			facts, want)
@@ -126,6 +126,27 @@ func TestMetricResourcesPerNode(t *testing.T) {
 	if want != value {
 		t.Errorf("Nodes() returned %f, want %f",
 			value, want)
+	}
+}
+
+func TestPuppetdbVersion(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/version",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "GET")
+			fmt.Fprint(w, `{ "version" : "2.2.0" },`)
+		})
+
+	facts, err := client.PuppetdbVersion()
+	if err != nil {
+		t.Errorf("PuppetdbVersion() returned error: %v", err)
+	}
+	want := PuppetdbVersion{"2.2.0"}
+	if !reflect.DeepEqual(facts, want) {
+		t.Errorf("PuppetdbVersion() returned %+v, want %+v",
+			facts, want)
 	}
 }
 


### PR DESCRIPTION
Hi Alex,

since I got credit for go-puppetdb, I need to create this PR to sleep well again. :smile: 

I added a function to get the version of PuppetDB, since I use this in a CLI to make sure the PuppetDB is available and used gofmt to ensure a consistent syntax (missed that the last time).

Finally, I removed the log-line. If that bothers you, I change it back and setup a debug parameter to exclude it at times. It was just a bit messy on the CLI.

Thanks!

Malte