### PR TITLE
Allows squelching of log.Printf()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ import (
 Create a Client with PuppetDB Hostname:
 
 ```go
-client := puppetdb.NewClient("http://127.0.0.1:8080")
+// second parameter enables verbose output
+client := puppetdb.NewClient("http://127.0.0.1:8080", true)
 
 resp, err := client.Nodes()
 ...
@@ -41,4 +42,6 @@ resp, res_err := client.Events(query, nil)
 # Contributors
 
 Malte Krupa (temal-)
+
+Will Roberts (willroberts)
 

--- a/puppetdb.go
+++ b/puppetdb.go
@@ -15,6 +15,7 @@ type Client struct {
 	PublicKey  string
 	SecretKey  string
 	httpClient *http.Client
+	verbose    bool
 }
 
 type EventCountJson struct {
@@ -76,10 +77,10 @@ type ValueMetricJson struct {
 	Value float64
 }
 
-func NewClient(baseUrl string) *Client {
+func NewClient(baseUrl string, verbose bool) *Client {
 	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 	client := &http.Client{Transport: tr}
-	return &Client{baseUrl, "", "", client}
+	return &Client{baseUrl, "", "", client, verbose}
 }
 
 func (c *Client) Get(v interface{}, path string, params map[string]string) error {
@@ -201,6 +202,8 @@ func mergeParam(paramName string, paramValue string, params map[string]string) m
 func (c *Client) httpGet(endpoint string) (resp *http.Response, err error) {
 	base := strings.TrimRight(c.BaseURL, "/")
 	url := fmt.Sprintf("%s/v3/%s", base, endpoint)
-	log.Printf(url)
+	if c.verbose == true {
+		log.Printf(url)
+	}
 	return c.httpClient.Get(url)
 }

--- a/puppetdb_test.go
+++ b/puppetdb_test.go
@@ -21,7 +21,7 @@ func setup() {
 
 	serverUrl, _ := url.Parse(server.URL)
 
-	client = NewClient(serverUrl.String())
+	client = NewClient(serverUrl.String(), true)
 }
 
 func teardown() {


### PR DESCRIPTION
When using `go-puppetdb` in command-line tools, the output of `log.Printf()` appears each time a query is made. This patch makes the output optional by gating it behind a `verbose` boolean in the `Client` type.

Since the signature of `NewClient()` has changed, I've also updated the docs and tests to match.