### PR TITLE
Add NewClientURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ resp, err := client.NodeFacts("node123")
 Queries can be represented as an array of strings and turned into JSON:
 
 ```go
-query, err := puppetdb.QueryToJson([]string{"=", "report", "aef00"})
+query, err := puppetdb.QueryToJSON([]string{"=", "report", "aef00"})
 resp, res_err := client.Events(query, nil)
 ```
 

--- a/puppetdb.go
+++ b/puppetdb.go
@@ -174,10 +174,15 @@ func getURL(host string, port int, ssl bool) string {
 
 // NewClient returns a http connection for your puppetdb instance.
 func NewClient(host string, port int, verbose bool) *Client {
-
 	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 	client := &http.Client{Transport: tr}
 	return &Client{getURL(host, port, false), "", "", client, verbose}
+}
+
+// NewClientURL returns a http connection for your puppetdb instance.
+func NewClientURL(url *url.URL, verbose bool) *Client {
+	client := &http.Client{}
+	return &Client{url.String(), "", "", client, verbose}
 }
 
 // NewClientSSL returns a https connection for your puppetdb instance.


### PR DESCRIPTION
This adds the ability to create a `Client` based on a `URL`. So that it's possible to use https without specifying a certificate.